### PR TITLE
Set default value to Y when entering no value

### DIFF
--- a/setup/scripts/tfc-setup.sh
+++ b/setup/scripts/tfc-setup.sh
@@ -19,6 +19,7 @@ echo "TFC Credential : $(cat ~/.terraform.d/credentials.tfrc.json)"
 echo
 read -r -p "Please verify this is correct? [Y/n] " REPLY
 echo
+REPLY="${REPLY:-Y}"
 if [[ ! $REPLY =~ ^[Yy]$ ]]
 then
   echo "Please try again...Reruning ~/setup/scripts/tfc-setup.sh"


### PR DESCRIPTION
The prompt 
"Please verify this is correct? [Y/n]"
gives the impression that the capital Y is the default value.